### PR TITLE
chore(packages): replace sha256 -> hash

### DIFF
--- a/precice-packages/aste/default.nix
+++ b/precice-packages/aste/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     owner = "precice";
     repo = "aste";
     rev = "v${version}";
-    sha256 = "sha256-hYqpM59NJGIOefMBFS2zd39lQyGoyU0ypJVdCzSsGT8=";
+    hash = "sha256-hYqpM59NJGIOefMBFS2zd39lQyGoyU0ypJVdCzSsGT8=";
   };
 
   nativeBuildInputs = [

--- a/precice-packages/aster/default.nix
+++ b/precice-packages/aster/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://www.code-aster.org/FICHIERS/aster-full-src-${version}-1.noarch.tar.gz";
-    sha256 = "sha256-3LOQDeHlwGJAYCU2YKY1EqtBXL4UPN2HhnoCdu9r8jM=";
+    hash = "sha256-3LOQDeHlwGJAYCU2YKY1EqtBXL4UPN2HhnoCdu9r8jM=";
   };
 
   patches = [

--- a/precice-packages/blacs/default.nix
+++ b/precice-packages/blacs/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://www.netlib.org/blacs/mpiblacs.tgz";
-    sha256 = "sha256-iN1yZdQSAilI3rt6JzcibNU6O/c7C2L8Vc6zzMilmPc=";
+    hash = "sha256-iN1yZdQSAilI3rt6JzcibNU6O/c7C2L8Vc6zzMilmPc=";
   };
 
   preBuild = ''

--- a/precice-packages/dealii-adapter/default.nix
+++ b/precice-packages/dealii-adapter/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "precice";
     repo = "dealii-adapter";
     rev = "dbb25bea51531b7e4e0c9b5e4def3a7fadf8367c";
-    sha256 = "sha256-pPQ2YEWiHPI4ph9mK3250TVzsAf9z5uYNae2jlflgUE=";
+    hash = "sha256-pPQ2YEWiHPI4ph9mK3250TVzsAf9z5uYNae2jlflgUE=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/precice-packages/dealii/default.nix
+++ b/precice-packages/dealii/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     owner = "dealii";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-Kz78U5ud36cTMq4E8FclOsmNsjMZfz+23tRXW/sl498=";
+    hash = "sha256-Kz78U5ud36cTMq4E8FclOsmNsjMZfz+23tRXW/sl498=";
   };
 
   nativeBuildInputs = [ cmake gcc ];

--- a/precice-packages/default.nix
+++ b/precice-packages/default.nix
@@ -17,7 +17,7 @@
       parmetis = super.parmetis.overrideAttrs (oA: rec {
         src = super.fetchurl {
           url = "https://web.archive.org/web/20221116225811/http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/parmetis-${oA.version}.tar.gz";
-          sha256 = "0pvfpvb36djvqlcc3lq7si0c5xpb2cqndjg8wvzg35ygnwqs5ngj";
+          hash = "sha256-8tmiMbfPl/H+5ujJZjET6/bCQNQH08EYxVs2M9a+bl8=";
         };
       });
 

--- a/precice-packages/mumps/default.nix
+++ b/precice-packages/mumps/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://graal.ens-lyon.fr/MUMPS/MUMPS_${version}.tar.gz";
-    sha256 = "sha256-Gr/ylPpH7kz9UN/VxZWUK3Lr/O3OCBQqdamas1AU+hU=";
+    hash = "sha256-Gr/ylPpH7kz9UN/VxZWUK3Lr/O3OCBQqdamas1AU+hU=";
   };
 
   preBuild = ''

--- a/precice-packages/openfoam-adapter/default.nix
+++ b/precice-packages/openfoam-adapter/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     owner = "precice";
     repo = "openfoam-adapter";
     rev = "v${version}";
-    sha256 = "sha256-+8VfiKIXzWXu2L/hd3IJV56BBWM/Nb73DWv4BTHvBbQ=";
+    hash = "sha256-+8VfiKIXzWXu2L/hd3IJV56BBWM/Nb73DWv4BTHvBbQ=";
   };
 
   nativeBuildInputs = [ openfoam pkg-config precice ];

--- a/precice-packages/openfoam/default.nix
+++ b/precice-packages/openfoam/default.nix
@@ -62,7 +62,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "https://develop.openfoam.com/Development/openfoam.git";
     rev = "OpenFOAM-v${version}";
-    sha256 = "sha256-snrFOsENf/siqFd1mzxAsYbw1ba67TXMgaNDpb26uX0=";
+    hash = "sha256-snrFOsENf/siqFd1mzxAsYbw1ba67TXMgaNDpb26uX0=";
   };
 
   nativeBuildInputs = [ gnumake m4 makeWrapper ];

--- a/vscode.nix
+++ b/vscode.nix
@@ -7,7 +7,7 @@ with import <nixpkgs> {};
       name = "code-gnu-global";
       publisher = "austin";
       version = "0.2.2";
-      sha256 = "sha256-pcFfBbcELEEBrOHSIZeZUu0CnYDpfc2Ni6oIJU1N6Ls=";
+      hash = "sha256-pcFfBbcELEEBrOHSIZeZUu0CnYDpfc2Ni6oIJU1N6Ls=";
     }
   ];
 })


### PR DESCRIPTION
sha256 was mostly replaced with the generic `hash` option