### PR TITLE
setup.sh: Clarify restarting

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -32,4 +32,4 @@ experimental-features = nix-command flakes
 EOF
 fi
 
-echo "-- Please open a new shell, after that nix-static should be available in your path"
+echo "-- Please restart your session (logout & login again). After that, nix-static should be available in your path."


### PR DESCRIPTION
`.profile` is not loaded when starting a new shell, but when starting a new login shell.